### PR TITLE
Fixed the build package error message in build-jdk.sh [1/1]

### DIFF
--- a/build-jdk.sh
+++ b/build-jdk.sh
@@ -15,7 +15,7 @@ bc_build() {
     local pkg
     for pkg in "${ORACLE_JAVA_RPMS[@]}"; do
 	[[ -f $BC_CACHE/$OS_TOKEN/pkgs/$pkg ]] || \
-	    die "Hadoop_clouderamanager build process did not build $pkg!"
+	    die "hadoop_infrastructure - JDK build process failed [$pkg]"
 	if [[ $CURRENT_CACHE_BRANCH ]]; then
 	    (cd "$BC_CACHE/$OS_TOKEN/pkgs"; git add "$pkg")
 	fi


### PR DESCRIPTION
Fixed the build package error message in build-jdk.sh.

 build-jdk.sh |    2 +-
 1 files changed, 1 insertions(+), 1 deletions(-)

Crowbar-Pull-ID: a96161d9e12e42108923b9b0144ee8b116e142b1

Crowbar-Release: roxy
