### PR TITLE
Fixed typo - removed line ender before do block on line 65. [1/1]

### DIFF
--- a/chef/cookbooks/hadoop_infrastructure/recipes/configure-disks.rb
+++ b/chef/cookbooks/hadoop_infrastructure/recipes/configure-disks.rb
@@ -61,8 +61,7 @@ BarclampLibrary::Barclamp::Inventory::Disk.unclaimed(node).each do |disk|
 end
 
 # Use all the disks claimed by Cloudera on this node.
-to_use_disks = BarclampLibrary::Barclamp::Inventory::Disk.claimed(node, "Cloudera").map
-do |d|
+to_use_disks = BarclampLibrary::Barclamp::Inventory::Disk.claimed(node, "Cloudera").map do |d|
   d.device
 end.sort
 


### PR DESCRIPTION
Fixed typo - removed line ender before do block on line 65.

 .../recipes/configure-disks.rb                     |    3 +--
 1 files changed, 1 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 75391ea27cb2b37b9fd7f71647b44631ad5d8b18

Crowbar-Release: hadoop-2.4
